### PR TITLE
Fix hero section height for large displays

### DIFF
--- a/src/assets/styles/Main.scss
+++ b/src/assets/styles/Main.scss
@@ -9,7 +9,9 @@
     align-items: center;
     width: 100%;
     padding: 0px 15%;
-    min-height: 700px;
+    // Ensure hero section fills the viewport below the fixed navigation bar
+    // 64px matches the AppBar height defined by Material UI
+    min-height: calc(100vh - 64px);
     background-image: url("../images/bg-dark.png");
     background-repeat: no-repeat;
     background-size: cover;


### PR DESCRIPTION
## Summary
- ensure the hero section spans the viewport by using a CSS calc with the navigation bar height

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install --silent` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68528eddcc18832aa5587e3ca4ce0fe4