### PR TITLE
Improve 404 navigation

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="My personal portfolio website."
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Nessim Ben Ammar</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {
   PageLayout,
   Portfolio,
 } from "./components";
-import { Legal, Project } from "./pages";
+import { Legal, Project, NotFound } from "./pages";
 import "./index.scss";
 
 function App() {
@@ -106,6 +106,10 @@ function App() {
       <Route
         path="/legal-notice"
         element={<Legal mode={mode} handleModeChange={handleModeChange} />}
+      />
+      <Route
+        path="*"
+        element={<NotFound mode={mode} handleModeChange={handleModeChange} />}
       />
     </Routes>
   );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -19,6 +19,7 @@ import Toolbar from "@mui/material/Toolbar";
 
 const drawerWidth = 240;
 const navItems = [
+  ["Home", "home"],
   ["Expertise", "expertise"],
   ["Experience", "experience"],
   ["Portfolio", "portfolio"],
@@ -60,6 +61,15 @@ function Navigation({ parentToChild, modeChange, isSubPage }: any) {
   };
 
   const handleNavClick = (section: string) => {
+    if (section === "home") {
+      if (isSubPage) {
+        navigate("/");
+      } else {
+        window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+      }
+      return;
+    }
+
     if (isSubPage) {
       sessionStorage.setItem("scrollTarget", section);
       navigate("/");

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { PageLayout } from "../components";
+
+interface NotFoundProps {
+  mode: string;
+  handleModeChange: () => void;
+}
+
+function NotFound({ mode, handleModeChange }: NotFoundProps) {
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+  }, []);
+
+  return (
+    <PageLayout mode={mode} handleModeChange={handleModeChange} isSubPage>
+      <div style={{ padding: "2rem" }}>
+        <h1>Page Not Found</h1>
+        <p>The page you're looking for does not exist.</p>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default NotFound;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as Legal } from "./Legal";
 export { default as Project } from "./Project";
+export { default as NotFound } from "./NotFound";


### PR DESCRIPTION
## Summary
- include a `Home` link in the navigation bar
- allow `Home` navigation from subpages and root

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552db39784832a8bb0ece041becd99